### PR TITLE
Feature/cucumber testing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,13 @@ repositories {
 
 //Dependencies of the software
 dependencies {
+        testImplementation(platform("org.junit:junit-bom:5.10.0"))
+        testImplementation(platform("io.cucumber:cucumber-bom:7.14.0"))
 
+        testImplementation ("io.cucumber:cucumber-java:7.14.0")
+        testImplementation("io.cucumber:cucumber-junit:7.14.0")
+        testImplementation("org.junit.platform:junit-platform-suite")
+        testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 tasks {
@@ -37,4 +43,14 @@ tasks {
     processResources {
         filteringCharset = Charsets.UTF_8.name() // We want UTF-8 for everything
     }
+
+
+
+}
+
+tasks.withType<Test> {
+        useJUnitPlatform()
+        // Work around. Gradle does not include enough information to disambiguate
+        // between different examples and scenarios.
+        systemProperty("cucumber.junit-platform.naming-strategy", "long")
 }

--- a/src/test/java/stepdefinitions/test_1.java
+++ b/src/test/java/stepdefinitions/test_1.java
@@ -1,0 +1,28 @@
+package stepdefinitions;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import io.cucumber.java.en.Then;
+import org.junit.jupiter.api.Assertions;
+
+public class test_1 {
+	@io.cucumber.java.en.Given("Cucumber is working")
+	public void cucumberIsWorking() {
+
+	}
+
+	@When("Cucumber is installed")
+	public void cucumberIsInstalled() {
+
+	}
+
+	@Then("I should see cucumber run tests it should return True")
+	public void iShouldSeeCucumberRunTestsItShouldReturnTrue() {
+		Assertions.assertTrue(true);
+	}
+
+	@Then("this test should fail")
+	public void thisTestShouldFail() {
+		Assertions.assertTrue(false);
+	}
+}

--- a/src/test/resources/features/test_1.feature
+++ b/src/test/resources/features/test_1.feature
@@ -1,0 +1,13 @@
+Feature: Cucumber Test
+      I need to validate that Cucumber is working properly
+
+      Scenario: Is Cucumber working
+            Given Cucumber is working
+            When Cucumber is installed
+            Then I should see cucumber run tests it should return True
+
+
+      Scenario: This test should fail
+            Given Cucumber is working
+            When Cucumber is installed
+            Then this test should fail


### PR DESCRIPTION
Added cucumber feature testing, which can be run with the cucumber+ intellij plugin, may need the other cucumber intellij plugins as well. Pretty simple to setup, but I can only do some basic testing without any codebase to test it on.